### PR TITLE
Remove Quartile Color from VoteButton.js

### DIFF
--- a/src/components/VoteButton/VoteButton.js
+++ b/src/components/VoteButton/VoteButton.js
@@ -1111,7 +1111,6 @@ class VoteButton extends Component {
                       totalVoters={currTotalVoters}
                       weight={formattedWeight}
                       isShown={isShown}
-                      quantile={currPostCatQuantile}
                     />
                   </Grid>
                 </Grid>


### PR DESCRIPTION
## :link: References

- **ClickUp Task:** https://app.clickup.com/t/2a23aw0
- **Other References:**

## :green_book: Summary
- quick removal of color (quartile) for votebutton for the sake of cleanup and in expectation of new votecomp. 

## :camera: Video or Screenshot
<img width="200" alt="image" src="https://user-images.githubusercontent.com/36429880/167113295-1a2d8079-1aa8-4534-8ded-8138b9ca75bf.png">


## :white_check_mark: Checklist:

- [x] I reviewed changes by myself.
- [x] I tested the changes in Desktop Mode.
- [x] I tested the changes in Mobile Mode.
