### PR TITLE
fix: prevent notif component from breaking if post is null

### DIFF
--- a/src/components/Notification/Notification.js
+++ b/src/components/Notification/Notification.js
@@ -115,7 +115,7 @@ class Notification extends Component {
 
     if (notif.post) {
       const { caption } = notif.post
-      return this.isCaptionLink(caption) ? caption : `/p/${notif.post._id.postid}`
+      return this.isCaptionLink(caption) ? caption : `/p/${notif.post && notif.post._id ? notif.post._id.postid : ''}`
     } else if (notif.action === 'follow') {
       return notif.invoker.eosname ? `/${notif.invoker.eosname}` : `/${notif.invoker}`
     }


### PR DESCRIPTION
## :link: References

- **ClickUp Task:**
- **Other References:**

## :green_book: Summary

## :camera: Video or Screenshot

## :white_check_mark: Checklist:

- [ ] I reviewed changes by myself.
- [ ] I tested the changes in Desktop Mode.
- [ ] I tested the changes in Mobile Mode.

Notifications component will break if the post is null